### PR TITLE
App options

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -103,6 +103,8 @@ function init(self)
 end
 ```
 
+It is possible to override the values within GoogleService-Info.plist/google-services.xml by passing an optional table of options to init(). See the [Defold manual](https://defold.com/extension-firebase/api/) for details but be aware of implications for analytics as described in Google's [Firebase documentation](https://firebase.google.com/docs/projects/multiprojects#reliable-analytics)
+
 ## Source code
 
 The source code is available on [GitHub](https://github.com/defold/extension-firebase)

--- a/firebase/api/firebase.script_api
+++ b/firebase/api/firebase.script_api
@@ -7,6 +7,14 @@
     type: function
     desc: Initialise Firebase
 
+    parameters:
+    - name: options
+      optional: true
+      type: table
+      desc: Optional table with initialisation parameters to use instead of those specified in google-services.xml/plist 
+            When passing this, disable creation of the default Firebase App by specifying firebase.no_auto_init in game.project
+            Valid keys in the table are api_key, app_id, database_url, messaging_sender_id, project_id, storage_bucket. All values are strings.
+
     return:
     - name: success
       type: boolean

--- a/firebase/manifests/android/AndroidManifest.xml
+++ b/firebase/manifests/android/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:tools="http://schemas.android.com/tools"
+	package="{{android.package}}">
+	<uses-sdk android:minSdkVersion="{{android.minimum_sdk_version}}" android:targetSdkVersion="{{android.target_sdk_version}}" />
+	<application>
+{{#firebase.no_auto_init}}
+		<provider
+			android:name="com.google.firebase.provider.FirebaseInitProvider"
+			android:authorities="{{android.package}}.firebaseinitprovider"
+			tools:node="remove"
+		/>
+{{/firebase.no_auto_init}}
+	</application>
+</manifest>


### PR DESCRIPTION
Implements #4 
- Reads options from an optional table parameter to init()
- Calls overloaded version of App::Create()
- new optional firebase.no_auto_init config value to control deleting FirebaseInitProvider in AndroidManifest.xml which otherwise initialises Firebase with default options provided in google services json