### PR TITLE
Update Firebase core SDKs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,8 @@ This extension allows you to interact with Firebase in a uniform way for games o
 * [Firebase Analytics](https://github.com/defold/extension-firebase-analytics)
 * [Firebase Remote Config](https://github.com/defold/extension-firebase-remoteconfig)
 
+Firebase Android SDK 34.x requires Android API level 23 or newer. Firebase Apple SDK 12.x requires iOS 15.0 or newer; the macOS extension manifest targets macOS 11.0 or newer.
+
 
 ## Setup
 ### 1. Firebase setup

--- a/firebase/manifests/android/build.gradle
+++ b/firebase/manifests/android/build.gradle
@@ -3,6 +3,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.google.firebase:firebase-installations:17.2.0'
-    implementation 'com.google.android.gms:play-services-base:18.2.0'
+    implementation platform('com.google.firebase:firebase-bom:34.16.0')
+    implementation 'com.google.firebase:firebase-installations'
+    implementation 'com.google.android.gms:play-services-base:18.10.0'
 }

--- a/firebase/manifests/ios/Podfile
+++ b/firebase/manifests/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '13.0'
+platform :ios, '15.0'
 
-pod 'FirebaseCore', '11.15.0'
-pod 'FirebaseInstallations', '11.15.0'
+pod 'FirebaseCore', '12.16.0'
+pod 'FirebaseInstallations', '12.16.0'

--- a/firebase/manifests/osx/Podfile
+++ b/firebase/manifests/osx/Podfile
@@ -1,4 +1,4 @@
 platform :osx, '11.0'
 
-pod 'FirebaseCore', '11.15.0'
-pod 'FirebaseInstallations', '11.15.0'
+pod 'FirebaseCore', '12.16.0'
+pod 'FirebaseInstallations', '12.16.0'

--- a/game.project
+++ b/game.project
@@ -27,6 +27,7 @@ infoplist = /builtins/manifests/ios/Info.plist
 
 [android]
 package = com.defold.firebase
+minimum_sdk_version = 23
 
 [osx]
 bundle_identifier = com.defold.firebase


### PR DESCRIPTION
## Summary

- Update the Android Firebase baseline to BoM 34.16.0.
- Resolve Firebase Installations 19.1.2 through the BoM and update Google Play services Base to 18.10.0.
- Update the Apple Firebase pods to 12.16.0.
- Raise the supported platform floors to Android API 23, iOS 15, and macOS 11.

## Why

These versions bring the extension onto the current Firebase release line and keep its explicit platform requirements aligned with the upstream SDK release notes. The newer Android and Apple SDKs no longer support the extension's previous platform floors, so the manifests now declare the required minimums rather than allowing incompatible builds.

The existing extension APIs remain compatible with the updated SDKs; the release-note review did not identify a native API migration beyond the platform requirement changes.

## Validation

The example project was successfully built with /Users/agulev/Downloads/bob.jar for:

- Android using the production Defold Extender
- iOS using the official staging Defold Extender
- macOS using the official staging Defold Extender

The staging service was used for Apple validation because the production Apple worker failed before receiving extension source code due to an Extender-side missing Mustache env value. The same sources built successfully on the official staging service, confirming this was infrastructure-specific rather than an extension build failure.